### PR TITLE
Add spec for initial chat API and UI

### DIFF
--- a/docs/specs/001-initial-chat-api-ui/spec.md
+++ b/docs/specs/001-initial-chat-api-ui/spec.md
@@ -1,0 +1,54 @@
+# Initial Chat API and UI
+
+## Overview
+Establish a minimal LangGraph-backed chat service that exposes an HTTP API and companion web client so operators can exercise the Phase 1 conversation loop end to end. The deliverable demonstrates message routing through the graph, returning responses, and rendering them in a thin browser UI.
+
+## Goals
+- Provide a documented HTTP endpoint that brokers chat turns through the LangGraph agent.
+- Deliver a lightweight web client that can submit prompts, stream/display responses, and show basic request metadata.
+- Ensure the API and UI scaffolding align with Phase 1 requirements and remain extensible toward memory inspection in later phases.
+
+## Non-Goals
+- Implement persistent memory storage or editing workflows (Phase 2 scope).
+- Add authentication, rate limiting, or production hardening beyond logging and error reporting.
+- Build advanced UI features such as memory visualization or multi-session management.
+
+## Functional Requirements
+- Define a Fastify route (e.g., `POST /api/chat`) accepting a validated payload with session identifier, user message, and optional config overrides.
+- Invoke the LangGraph agent graph per request, returning assistant messages and structured metadata (timestamps, node trace identifiers).
+- Support incremental/streaming responses via Server-Sent Events (SSE) or chunked JSON with fall back to buffered replies.
+- Implement client-side interface with input form, message history pane, and status indicators using approved frontend stack (e.g., Vite + React per tech guardrails).
+- Display request/response metadata (latency, token counts if available) alongside messages for operator insight.
+- Provide inline error handling surfaced to the client UI with actionable messaging.
+
+## Non-Functional Requirements
+- Adhere to TypeScript code style and linting rules across server and client packages.
+- Log structured events with Pino, including correlation IDs for each chat turn.
+- Ensure API responds within hobbyist-friendly latency budgets (target <5s for default model) and handles concurrent requests gracefully.
+- Write unit/integration tests covering request validation, graph invocation, and frontend component rendering.
+- Document setup, configuration, and troubleshooting steps in repository docs.
+
+## User Stories
+- As an operator, I want to send a message through the API so that I can verify the LangGraph agent responds correctly.
+- As an operator, I want a simple web UI so that I can interact with the chatbot without crafting manual HTTP requests.
+- As a developer, I want structured logs and metadata so that I can debug graph execution issues quickly.
+
+## Edge Cases
+- Network or LLM provider timeouts during graph execution (must surface retriable error state to UI).
+- Invalid request payloads (UI should prevent submission and API must return descriptive validation errors).
+- SSE/stream transport unsupported by browser (fallback to buffered response).
+- Multiple rapid submissions creating race conditions in UI rendering order.
+
+## Open Questions
+- TBD: Confirm preferred transport for streaming (SSE vs. WebSocket) within infrastructure constraints.
+- TBD: Determine minimum metadata set to expose (token usage availability depends on model provider).
+- TBD: Clarify how session identifiers map to future memory persistence expectations.
+
+## Clarifications
+### Session 2024-XX-XX
+- Pending clarification.
+
+## References
+- docs/mission.md
+- docs/best-practices.md
+- docs/tech-stack.md


### PR DESCRIPTION
## Summary
- create the first feature spec directory for the chat API and companion UI
- document goals, requirements, and open questions for delivering a minimal LangGraph-powered endpoint and web client

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78dcb0908832d9da62cc659ce4b8c